### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/src/core/lazyload.ts
+++ b/src/core/lazyload.ts
@@ -8,7 +8,7 @@ export function resolveLazyload (config: Options) {
 
   return {
     filename: `${libraryName}-lazyload.plugin.mjs`,
-    getContents: () => `import { defineNuxtPlugin } from '#app';
+    getContents: () => `import { defineNuxtPlugin } from '#imports';
 import { Lazyload } from 'vant';
 
 export default defineNuxtPlugin(nuxtApp => {


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.